### PR TITLE
Add --base-url flag for connector testability

### DIFF
--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -8,6 +8,7 @@ type Cloudflare struct {
 	ApiToken string `mapstructure:"api-token"`
 	AccountId string `mapstructure:"account-id"`
 	EmailId string `mapstructure:"email-id"`
+	BaseUrl string `mapstructure:"base-url"`
 }
 
 func (c *Cloudflare) findFieldByTag(tagValue string) (any, bool) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,11 +31,18 @@ var (
 		field.WithDescription("The email id for the Cloudflare account."),
 		field.WithRequired(true),
 	)
+	baseUrlField = field.StringField(
+		"base-url",
+		field.WithDescription("Override the Cloudflare API URL (for testing)"),
+		field.WithHidden(true),
+		field.WithExportTarget(field.ExportTargetCLIOnly),
+	)
 	configurationFields = []field.SchemaField{
 		apiKeyField,
 		apiTokenField,
 		accountIdField,
 		emailIdField,
+		baseUrlField,
 	}
 )
 

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -22,6 +22,7 @@ func New(ctx context.Context, cc *cfg.Cloudflare, opts *cli.ConnectorOpts) (conn
 		apiToken  = cc.ApiToken
 		accountId = cc.AccountId
 		emailId   = cc.EmailId
+		baseURL   = cc.BaseUrl
 		err       error
 	)
 
@@ -30,15 +31,21 @@ func New(ctx context.Context, cc *cfg.Cloudflare, opts *cli.ConnectorOpts) (conn
 		return nil, nil, err
 	}
 
+	// Build options slice
+	cfOpts := []cloudflare.Option{cloudflare.HTTPClient(httpClient)}
+	if baseURL != "" {
+		cfOpts = append(cfOpts, cloudflare.BaseURL(baseURL))
+	}
+
 	if apiToken != "" {
-		client, err = cloudflare.NewWithAPIToken(apiToken, cloudflare.HTTPClient(httpClient))
+		client, err = cloudflare.NewWithAPIToken(apiToken, cfOpts...)
 		if err != nil {
 			return nil, nil, err
 		}
 	}
 
 	if apiKey != "" && emailId != "" {
-		client, err = cloudflare.New(apiKey, emailId, cloudflare.HTTPClient(httpClient))
+		client, err = cloudflare.New(apiKey, emailId, cfOpts...)
 		if err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
## Summary

Adds the `--base-url` CLI flag to enable overriding the default API endpoint for testing purposes.

## Changes

- Added `BaseURLField` to configuration
- Updated client/connector to accept and use the base URL override
- When `--base-url` is provided, it takes precedence over the default API URL

## Files Modified

```
cmd/baton-cloudflare/main.go,pkg/config/conf.gen.go,pkg/config/config.go,pkg/connector/connector.go,pkg/connector/model.go
```

## Testing

The connector can now be tested against mock servers:
```bash
baton-cloudflare --base-url http://localhost:8080 [other-flags]
```

## Related

Part of the Connector Testability initiative.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration option to specify a custom Cloudflare API URL endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->