### PR TITLE
CXP-598 Support invitations on sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ baton resources
 `baton-cloudflare` will pull down information about the following cloudflare resources:
 - Users
   - Users supervisors
-  - roles
+  - Roles
+- Invitations — pending account invitations are synced as a separate resource type. Users who have been invited but have not yet accepted appear as `Invitation` resources with a `Pending` status. Once the invitation is accepted, the user will appear as a regular `User` resource on the next sync.
 
 # Contributing, Support and Issues
 

--- a/baton_capabilities.json
+++ b/baton_capabilities.json
@@ -3,6 +3,29 @@
   "resourceTypeCapabilities": [
     {
       "resourceType": {
+        "id": "invitation",
+        "displayName": "Invitation",
+        "traits": [
+          "TRAIT_USER"
+        ],
+        "annotations": [
+          {
+            "@type": "type.googleapis.com/c1.connector.v2.V1Identifier",
+            "id": "invitation"
+          },
+          {
+            "@type": "type.googleapis.com/c1.connector.v2.SkipEntitlementsAndGrants"
+          }
+        ]
+      },
+      "capabilities": [
+        "CAPABILITY_SYNC",
+        "CAPABILITY_RESOURCE_DELETE"
+      ],
+      "permissions": {}
+    },
+    {
+      "resourceType": {
         "id": "role",
         "displayName": "Role",
         "traits": [

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -16,6 +16,11 @@ sidebarTitle: "Cloudflare"
 | :--- | :--- | :--- |
 | Accounts | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |
 | Roles | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |
+| Invitations | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="xmark" iconType="solid" color="#808080"/> |
+
+<Note>
+**Invitations** represent pending account invitations — users who have been invited to the Cloudflare account but have not yet accepted. They appear as `Invitation` resources with a `Pending` status. Once a user accepts their invitation, they will transition to a regular `User` resource on the next sync.
+</Note>
 
 ## Gather Cloudflare credentials
 

--- a/go.mod
+++ b/go.mod
@@ -113,7 +113,7 @@ require (
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
-	golang.org/x/text v0.36.0 // indirect
+	golang.org/x/text v0.36.0
 	golang.org/x/time v0.8.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260504160031-60b97b32f348 // indirect
 	google.golang.org/grpc v1.81.0 // indirect

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -112,12 +112,12 @@ func (c *Cloudflare) Metadata(ctx context.Context) (*v2.ConnectorMetadata, error
 func (c *Cloudflare) Validate(ctx context.Context) (annotations.Annotations, error) {
 	if c.accountId != "" {
 		if c.client == nil {
-			return nil, fmt.Errorf("Cloudflare: client not configured. API key/email or token not provided")
+			return nil, fmt.Errorf("baton-cloudflare: client not configured, API key/email or token not provided")
 		}
 
 		_, _, err := c.client.Account(ctx, c.accountId)
 		if err != nil {
-			return nil, fmt.Errorf("Cloudflare: failed to validate API keys: %w", err)
+			return nil, fmt.Errorf("baton-cloudflare: failed to validate API keys: %w", err)
 		}
 	}
 

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -124,13 +124,14 @@ func (c *Cloudflare) Validate(ctx context.Context) (annotations.Annotations, err
 	return nil, nil
 }
 
-func (c *Cloudflare) Asset(ctx context.Context, asset *v2.AssetRef) (string, io.ReadCloser, error) {
+func (c *Cloudflare) Asset(_ context.Context, _ *v2.AssetRef) (string, io.ReadCloser, error) {
 	return "", nil, nil
 }
 
-func (c *Cloudflare) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSyncerV2 {
+func (c *Cloudflare) ResourceSyncers(_ context.Context) []connectorbuilder.ResourceSyncerV2 {
 	return []connectorbuilder.ResourceSyncerV2{
 		userBuilder(c.client, c.accountId),
+		invitationBuilder(c.client, c.accountId),
 		roleBuilder(c.client, c.accountId, c.emailId),
 	}
 }

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -15,7 +15,7 @@ import (
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 )
 
-func New(ctx context.Context, cc *cfg.Cloudflare, opts *cli.ConnectorOpts) (connectorbuilder.ConnectorBuilderV2, []connectorbuilder.Opt, error) {
+func New(ctx context.Context, cc *cfg.Cloudflare, _ *cli.ConnectorOpts) (connectorbuilder.ConnectorBuilderV2, []connectorbuilder.Opt, error) {
 	var (
 		client    *cloudflare.API
 		apiKey    = cc.ApiKey

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -131,7 +131,7 @@ func (c *Cloudflare) Asset(_ context.Context, _ *v2.AssetRef) (string, io.ReadCl
 func (c *Cloudflare) ResourceSyncers(_ context.Context) []connectorbuilder.ResourceSyncerV2 {
 	return []connectorbuilder.ResourceSyncerV2{
 		userBuilder(c.client, c.accountId),
-		invitationBuilder(c.client, c.accountId),
+		invitationBuilder(c.client, c.accountId, c.emailId),
 		roleBuilder(c.client, c.accountId, c.emailId),
 	}
 }

--- a/pkg/connector/errors.go
+++ b/pkg/connector/errors.go
@@ -3,5 +3,5 @@ package connector
 import "fmt"
 
 func wrapError(err error, message string) error {
-	return fmt.Errorf("cloudflare-connector: %s: %w", message, err)
+	return fmt.Errorf("baton-cloudflare: %s: %w", message, err)
 }

--- a/pkg/connector/helpers.go
+++ b/pkg/connector/helpers.go
@@ -55,6 +55,12 @@ func v1AnnotationsWithPermissions(resourceTypeID string, perms *v2.CapabilityPer
 	return annos
 }
 
+func v1AnnotationsSkipEntitlementsAndGrants(resourceTypeID string) annotations.Annotations {
+	annos := v1AnnotationsForResourceType(resourceTypeID)
+	annos.Update(&v2.SkipEntitlementsAndGrants{})
+	return annos
+}
+
 func V1MembershipEntitlementID(resourceID string) string {
 	return fmt.Sprintf(MembershipEntitlementIDTemplate, resourceID)
 }

--- a/pkg/connector/helpers.go
+++ b/pkg/connector/helpers.go
@@ -92,7 +92,7 @@ func getError(err error) error {
 	}
 
 	if errors.As(err, &bitbucketErr) {
-		return fmt.Errorf("%s %s", bitbucketErr.Error(), bitbucketErr.ErrorSummary)
+		return fmt.Errorf("baton-cloudflare: %s: %s", bitbucketErr.Error(), bitbucketErr.ErrorSummary)
 	}
 
 	return err
@@ -132,7 +132,7 @@ func findMemberIDByUserID(ctx context.Context, client *cloudflare.API, accountID
 		page++
 	}
 
-	return "", fmt.Errorf("%w for user ID %s", errMemberNotFound, userID)
+	return "", fmt.Errorf("baton-cloudflare: %w for user ID %s", errMemberNotFound, userID)
 }
 
 // getAccountInfo extracts the primary email and optional first/last name from AccountInfo.

--- a/pkg/connector/invitation.go
+++ b/pkg/connector/invitation.go
@@ -4,17 +4,25 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
 
 	"github.com/cloudflare/cloudflare-go"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
+	"github.com/conductorone/baton-sdk/pkg/uhttp"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 type InvitationResourceType struct {
 	resourceType *v2.ResourceType
 	client       *cloudflare.API
 	accountId    string
+	emailId      string
 }
 
 func (o *InvitationResourceType) ResourceType(_ context.Context) *v2.ResourceType {
@@ -23,14 +31,15 @@ func (o *InvitationResourceType) ResourceType(_ context.Context) *v2.ResourceTyp
 
 func invitationResource(member cloudflare.AccountMember) (*v2.Resource, error) {
 	email := member.User.Email
+	status := cases.Title(language.English).String(member.Status)
 	profile := map[string]interface{}{
 		"email":  email,
-		"status": member.Status,
+		"status": status,
 	}
 
 	userTraits := []rs.UserTraitOption{
 		rs.WithUserProfile(profile),
-		rs.WithStatus(v2.UserTrait_Status_STATUS_UNSPECIFIED),
+		rs.WithDetailedStatus(v2.UserTrait_Status_STATUS_ENABLED, status),
 		rs.WithUserLogin(email),
 		rs.WithEmail(email, true),
 	}
@@ -45,25 +54,71 @@ func invitationResource(member cloudflare.AccountMember) (*v2.Resource, error) {
 	return resource, nil
 }
 
+// listPendingMembers fetches only pending account members from the Cloudflare API using a
+// raw HTTP call with ?status=pending.
+//
+// The cloudflare-go SDK's AccountMembers() only accepts PaginationOptions (page + per_page)
+// and does not expose the status query parameter supported by the REST API
+// (GET /accounts/{id}/members?status=pending|accepted|rejected).
+// Until the SDK adds a dedicated filter params struct we call the endpoint directly so that
+// only pending invitations are returned, avoiding a full member scan on every sync.
+func (o *InvitationResourceType) listPendingMembers(ctx context.Context, page int) ([]cloudflare.AccountMember, cloudflare.ResultInfo, error) {
+	httpClient, err := uhttp.NewClient(ctx, uhttp.WithLogger(true, ctxzap.Extract(ctx)))
+	if err != nil {
+		return nil, cloudflare.ResultInfo{}, err
+	}
+
+	baseClient := uhttp.NewBaseHttpClient(httpClient)
+
+	params := url.Values{}
+	params.Set("status", "pending")
+	params.Set("page", strconv.Itoa(page))
+	endpointURL := fmt.Sprintf("%s/accounts/%s/members?%s", o.client.BaseURL, o.accountId, params.Encode())
+
+	uri, err := url.Parse(endpointURL)
+	if err != nil {
+		return nil, cloudflare.ResultInfo{}, err
+	}
+
+	opts := []uhttp.RequestOption{
+		uhttp.WithAcceptJSONHeader(),
+		uhttp.WithBearerToken(o.client.APIToken),
+	}
+	if o.emailId != "" {
+		opts = append(opts, uhttp.WithHeader(XAuthEmailHeaderKey, o.emailId))
+	}
+	if o.client.APIKey != "" {
+		opts = append(opts, uhttp.WithHeader(XAuthKeyHeaderKey, o.client.APIKey))
+	}
+
+	req, err := baseClient.NewRequest(ctx, http.MethodGet, uri, opts...)
+	if err != nil {
+		return nil, cloudflare.ResultInfo{}, err
+	}
+
+	var response cloudflare.AccountMembersListResponse
+	_, err = baseClient.Do(req, uhttp.WithJSONResponse(&response))
+	if err != nil {
+		return nil, cloudflare.ResultInfo{}, fmt.Errorf("baton-cloudflare: failed to list pending invitations: %w", err)
+	}
+
+	return response.Result, response.ResultInfo, nil
+}
+
 func (o *InvitationResourceType) List(ctx context.Context, _ *v2.ResourceId, opts rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
 	page, err := convertPageToken(opts.PageToken.Token)
 	if err != nil {
 		return nil, nil, fmt.Errorf("baton-cloudflare: invalid page token error")
 	}
 
-	pageOpts := cloudflare.PaginationOptions{Page: page}
-	members, resp, err := o.client.AccountMembers(ctx, o.accountId, pageOpts)
+	members, resultInfo, err := o.listPendingMembers(ctx, page)
 	if err != nil {
-		return nil, nil, fmt.Errorf("baton-cloudflare: could not retrieve account members: %w", err)
+		return nil, nil, err
 	}
 
-	nextPage := convertNextPageToken(resp.Page, len(members))
-	rv := make([]*v2.Resource, 0)
+	nextPage := convertNextPageToken(resultInfo.Page, len(members))
+	rv := make([]*v2.Resource, 0, len(members))
 	for _, member := range members {
-		// Only capture pending invitations — accepted members are handled by the user resource type.
-		if member.User.ID != "" {
-			continue
-		}
 		resource, err := invitationResource(member)
 		if err != nil {
 			return nil, nil, err
@@ -101,10 +156,11 @@ func (o *InvitationResourceType) Delete(ctx context.Context, resourceId *v2.Reso
 	return nil, nil
 }
 
-func invitationBuilder(client *cloudflare.API, accountId string) *InvitationResourceType {
+func invitationBuilder(client *cloudflare.API, accountId, emailId string) *InvitationResourceType {
 	return &InvitationResourceType{
 		resourceType: resourceTypeInvitation,
 		client:       client,
 		accountId:    accountId,
+		emailId:      emailId,
 	}
 }

--- a/pkg/connector/invitation.go
+++ b/pkg/connector/invitation.go
@@ -97,11 +97,12 @@ func (o *InvitationResourceType) listPendingMembers(ctx context.Context, page in
 	}
 
 	var response cloudflare.AccountMembersListResponse
-	_, err = baseClient.Do(req, uhttp.WithJSONResponse(&response))
+	resp, err := baseClient.Do(req, uhttp.WithJSONResponse(&response))
 	if err != nil {
 		return nil, cloudflare.ResultInfo{}, fmt.Errorf("baton-cloudflare: failed to list pending invitations: %w", err)
 	}
 
+	defer resp.Body.Close()
 	return response.Result, response.ResultInfo, nil
 }
 

--- a/pkg/connector/invitation.go
+++ b/pkg/connector/invitation.go
@@ -1,0 +1,110 @@
+package connector
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/cloudflare/cloudflare-go"
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
+	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
+)
+
+type InvitationResourceType struct {
+	resourceType *v2.ResourceType
+	client       *cloudflare.API
+	accountId    string
+}
+
+func (o *InvitationResourceType) ResourceType(_ context.Context) *v2.ResourceType {
+	return o.resourceType
+}
+
+func invitationResource(member cloudflare.AccountMember) (*v2.Resource, error) {
+	email := member.User.Email
+	profile := map[string]interface{}{
+		"email":  email,
+		"status": member.Status,
+	}
+
+	userTraits := []rs.UserTraitOption{
+		rs.WithUserProfile(profile),
+		rs.WithStatus(v2.UserTrait_Status_STATUS_UNSPECIFIED),
+		rs.WithUserLogin(email),
+		rs.WithEmail(email, true),
+	}
+
+	// member.ID (the membership UUID) is used as the resource ID because member.User.ID
+	// is empty for pending invitations until the user accepts and gets a Cloudflare UUID.
+	resource, err := rs.NewUserResource(email, resourceTypeInvitation, member.ID, userTraits)
+	if err != nil {
+		return nil, err
+	}
+
+	return resource, nil
+}
+
+func (o *InvitationResourceType) List(ctx context.Context, _ *v2.ResourceId, opts rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
+	page, err := convertPageToken(opts.PageToken.Token)
+	if err != nil {
+		return nil, nil, fmt.Errorf("baton-cloudflare: invalid page token error")
+	}
+
+	pageOpts := cloudflare.PaginationOptions{Page: page}
+	members, resp, err := o.client.AccountMembers(ctx, o.accountId, pageOpts)
+	if err != nil {
+		return nil, nil, fmt.Errorf("baton-cloudflare: could not retrieve account members: %w", err)
+	}
+
+	nextPage := convertNextPageToken(resp.Page, len(members))
+	rv := make([]*v2.Resource, 0)
+	for _, member := range members {
+		// Only capture pending invitations — accepted members are handled by the user resource type.
+		if member.User.ID != "" {
+			continue
+		}
+		resource, err := invitationResource(member)
+		if err != nil {
+			return nil, nil, err
+		}
+		rv = append(rv, resource)
+	}
+
+	return rv, &rs.SyncOpResults{NextPageToken: nextPage}, nil
+}
+
+func (o *InvitationResourceType) Entitlements(_ context.Context, _ *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
+	return nil, nil, nil
+}
+
+func (o *InvitationResourceType) Grants(_ context.Context, _ *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
+	return nil, nil, nil
+}
+
+// Delete cancels a pending invitation.
+// The resource ID is the membership UUID (member.ID), which is what the Cloudflare delete API requires.
+func (o *InvitationResourceType) Delete(ctx context.Context, resourceId *v2.ResourceId, _ *v2.ResourceId) (annotations.Annotations, error) {
+	if resourceId.ResourceType != resourceTypeInvitation.Id {
+		return nil, fmt.Errorf("baton-cloudflare: invalid resource type for delete: %s", resourceId.ResourceType)
+	}
+
+	err := o.client.DeleteAccountMember(ctx, o.accountId, resourceId.Resource)
+	if err != nil {
+		var notFound *cloudflare.NotFoundError
+		if errors.As(err, &notFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("baton-cloudflare: failed to cancel invitation: %w", err)
+	}
+
+	return nil, nil
+}
+
+func invitationBuilder(client *cloudflare.API, accountId string) *InvitationResourceType {
+	return &InvitationResourceType{
+		resourceType: resourceTypeInvitation,
+		client:       client,
+		accountId:    accountId,
+	}
+}

--- a/pkg/connector/invitation.go
+++ b/pkg/connector/invitation.go
@@ -18,6 +18,8 @@ import (
 	"golang.org/x/text/language"
 )
 
+const userStatusPending = "pending"
+
 type InvitationResourceType struct {
 	resourceType *v2.ResourceType
 	client       *cloudflare.API
@@ -71,7 +73,7 @@ func (o *InvitationResourceType) listPendingMembers(ctx context.Context, page in
 	baseClient := uhttp.NewBaseHttpClient(httpClient)
 
 	params := url.Values{}
-	params.Set("status", "pending")
+	params.Set("status", userStatusPending)
 	params.Set("page", strconv.Itoa(page))
 	endpointURL := fmt.Sprintf("%s/accounts/%s/members?%s", o.client.BaseURL, o.accountId, params.Encode())
 

--- a/pkg/connector/resource_types.go
+++ b/pkg/connector/resource_types.go
@@ -23,7 +23,7 @@ var (
 		Traits: []v2.ResourceType_Trait{
 			v2.ResourceType_TRAIT_USER,
 		},
-		Annotations: v1AnnotationsForResourceType("invitation"),
+		Annotations: v1AnnotationsSkipEntitlementsAndGrants("invitation"),
 	}
 	resourceTypeRole = &v2.ResourceType{
 		Id:          "role",

--- a/pkg/connector/resource_types.go
+++ b/pkg/connector/resource_types.go
@@ -17,6 +17,14 @@ var (
 			"Account Settings: Edit",
 		)),
 	}
+	resourceTypeInvitation = &v2.ResourceType{
+		Id:          "invitation",
+		DisplayName: "Invitation",
+		Traits: []v2.ResourceType_Trait{
+			v2.ResourceType_TRAIT_USER,
+		},
+		Annotations: v1AnnotationsForResourceType("invitation"),
+	}
 	resourceTypeRole = &v2.ResourceType{
 		Id:          "role",
 		DisplayName: "Role",

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -69,7 +69,7 @@ func roleResource(role cloudflare.AccountRole, resourceTypeRole *v2.ResourceType
 	return ret, nil
 }
 
-func (o *roleResourceType) List(ctx context.Context, _ *v2.ResourceId, opts rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
+func (o *roleResourceType) List(ctx context.Context, _ *v2.ResourceId, _ rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
 	// Empty params causes ListAccountRoles to auto paginate and return all account roles
 	params := cloudflare.ListAccountRolesParams{}
 	roles, err := o.client.ListAccountRoles(ctx, cloudflare.AccountIdentifier(o.accountId), params)
@@ -97,7 +97,7 @@ func (o *roleResourceType) List(ctx context.Context, _ *v2.ResourceId, opts rs.S
 	return rv, &rs.SyncOpResults{}, nil
 }
 
-func (r *roleResourceType) Entitlements(ctx context.Context, resource *v2.Resource, opts rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
+func (r *roleResourceType) Entitlements(_ context.Context, resource *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
 	rv := []*v2.Entitlement{
 		ent.NewAssignmentEntitlement(
 			resource,
@@ -155,7 +155,7 @@ func (r *roleResourceType) GetAccountMember(ctx context.Context, accountID strin
 
 	resp, err := r.httpClient.Do(req, uhttp.WithJSONResponse(&accountMemberListResponse))
 	if err != nil {
-		return nil, fmt.Errorf("%s %s", err.Error(), resp.Body)
+		return nil, fmt.Errorf("baton-cloudflare: failed to get account member: %w", err)
 	}
 
 	defer resp.Body.Close()
@@ -166,7 +166,7 @@ func (r *roleResourceType) Grants(ctx context.Context, resource *v2.Resource, op
 	var rv []*v2.Grant
 	page, err := convertPageToken(opts.PageToken.Token)
 	if err != nil {
-		return nil, nil, fmt.Errorf("Cloudflare: invalid page token error")
+		return nil, nil, fmt.Errorf("baton-cloudflare: invalid page token error")
 	}
 
 	pageOpts := cloudflare.PaginationOptions{Page: page}
@@ -178,6 +178,11 @@ func (r *roleResourceType) Grants(ctx context.Context, resource *v2.Resource, op
 	roleId := resource.Id.Resource
 	nextPage := convertNextPageToken(resp.Page, len(users))
 	for _, user := range users {
+		// Pending invitations have no User.ID yet.
+		if user.User.ID == "" {
+			continue
+		}
+
 		userPos := slices.IndexFunc(user.Roles, func(r cloudflare.AccountRole) bool {
 			return r.ID == roleId
 		})
@@ -242,7 +247,7 @@ func (r *roleResourceType) Grant(ctx context.Context, principal *v2.Resource, en
 
 	account, err := r.GetAccountMember(ctx, r.accountId, memberId)
 	if err != nil {
-		return nil, fmt.Errorf("error: %s", err.Error())
+		return nil, fmt.Errorf("baton-cloudflare: failed to get account member: %w", err)
 	}
 
 	roles := []cloudflare.AccountRole{
@@ -364,11 +369,11 @@ func (r *roleResourceType) Revoke(ctx context.Context, grant *v2.Grant) (annotat
 	principal := grant.Principal
 	if principal.Id.ResourceType != resourceTypeUser.Id {
 		l.Warn(
-			"couldflare-connector: only users can have role membership revoked",
+			"baton-cloudflare: only users can have role membership revoked",
 			zap.String("principal_type", principal.Id.ResourceType),
 			zap.String("principal_id", principal.Id.Resource),
 		)
-		return nil, fmt.Errorf("couldflare-connector: only users can have role membership revoked")
+		return nil, fmt.Errorf("baton-cloudflare: only users can have role membership revoked")
 	}
 
 	userId := principal.Id.Resource

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -72,7 +72,7 @@ func (o *UserResourceType) List(ctx context.Context, _ *v2.ResourceId, opts rs.S
 	rv := make([]*v2.Resource, 0, len(users))
 	for _, user := range users {
 		// Pending invitations have no User.ID yet; they are listed by the invitation resource type.
-		if user.User.ID == "" {
+		if user.Status == userStatusPending || user.User.ID == "" {
 			continue
 		}
 
@@ -140,16 +140,10 @@ func (o *UserResourceType) CreateAccount(
 		member.User.LastName = lastName
 	}
 
-	// When the invited address has no existing Cloudflare account, User.ID is empty until accepted.
-	// Return an invitation resource in that case so C1 gets a valid resource back.
 	var resource *v2.Resource
-	if member.User.ID == "" {
-		resource, err = invitationResource(member)
-	} else {
-		resource, err = userResource(member)
-	}
+	resource, err = invitationResource(member)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("baton-cloudflare: failed to build resource after invite: %w", err)
+		return nil, nil, nil, fmt.Errorf("baton-cloudflare: failed to build invitation resource after invite: %w", err)
 	}
 
 	return &v2.CreateAccountResponse_ActionRequiredResult{

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -59,13 +59,13 @@ func userResource(member cloudflare.AccountMember) (*v2.Resource, error) {
 func (o *UserResourceType) List(ctx context.Context, _ *v2.ResourceId, opts rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
 	page, err := convertPageToken(opts.PageToken.Token)
 	if err != nil {
-		return nil, nil, fmt.Errorf("Cloudflare: invalid page token error")
+		return nil, nil, fmt.Errorf("baton-cloudflare: invalid page token error")
 	}
 
 	pageOpts := cloudflare.PaginationOptions{Page: page}
 	users, resp, err := o.client.AccountMembers(ctx, o.accountId, pageOpts)
 	if err != nil {
-		return nil, nil, fmt.Errorf("cloudflare: could not retrieve users: %w", err)
+		return nil, nil, fmt.Errorf("baton-cloudflare: could not retrieve users: %w", err)
 	}
 
 	nextPage := convertNextPageToken(resp.Page, len(users))

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -71,6 +71,11 @@ func (o *UserResourceType) List(ctx context.Context, _ *v2.ResourceId, opts rs.S
 	nextPage := convertNextPageToken(resp.Page, len(users))
 	rv := make([]*v2.Resource, 0, len(users))
 	for _, user := range users {
+		// Pending invitations have no User.ID yet; they are listed by the invitation resource type.
+		if user.User.ID == "" {
+			continue
+		}
+
 		userResource, err := userResource(user)
 		if err != nil {
 			return nil, nil, err
@@ -135,9 +140,16 @@ func (o *UserResourceType) CreateAccount(
 		member.User.LastName = lastName
 	}
 
-	resource, err := userResource(member)
+	// When the invited address has no existing Cloudflare account, User.ID is empty until accepted.
+	// Return an invitation resource in that case so C1 gets a valid resource back.
+	var resource *v2.Resource
+	if member.User.ID == "" {
+		resource, err = invitationResource(member)
+	} else {
+		resource, err = userResource(member)
+	}
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("baton-cloudflare: failed to build user resource after invite: %w", err)
+		return nil, nil, nil, fmt.Errorf("baton-cloudflare: failed to build resource after invite: %w", err)
 	}
 
 	return &v2.CreateAccountResponse_ActionRequiredResult{


### PR DESCRIPTION
There is a bug on the syncs which fail when there is a pending invitation. 
This PR addresses the bug avoiding the error and also includes support for Invitations, so the users can see them listed