### PR TITLE
fix: return AlreadyExists on CreateAccount when member already exists (CXP-649)

### DIFF
--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-
 	"github.com/cloudflare/cloudflare-go"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
@@ -128,6 +127,11 @@ func (o *UserResourceType) CreateAccount(
 		Status:       "pending",
 	})
 	if err != nil {
+		// 1008: "Account member already exists for email address" (Cloudflare API error code)
+		var reqErr cloudflare.RequestError
+		if errors.As(err, &reqErr) && reqErr.InternalErrorCodeIs(1008) {
+			return &v2.CreateAccountResponse_AlreadyExistsResult{}, nil, nil, nil
+		}
 		return nil, nil, nil, fmt.Errorf("baton-cloudflare: failed to invite account member: %w", err)
 	}
 

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -128,7 +128,7 @@ func (o *UserResourceType) CreateAccount(
 	})
 	if err != nil {
 		// 1008: "Account member already exists for email address" (Cloudflare API error code)
-		var reqErr cloudflare.RequestError
+		var reqErr *cloudflare.RequestError
 		if errors.As(err, &reqErr) && reqErr.InternalErrorCodeIs(1008) {
 			return &v2.CreateAccountResponse_AlreadyExistsResult{}, nil, nil, nil
 		}


### PR DESCRIPTION
## Summary
- Returns `CreateAccountResponse_AlreadyExistsResult` instead of an error when `CreateAccountMember` fails with Cloudflare error code 1008 ("Account member already exists for email address")

## Test plan
- [ ] Trigger CreateAccount for an email that is already a member of the Cloudflare account
- [ ] Confirm the response is `AlreadyExists` (not an error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)