### PR TITLE
fix: sync user status from member.status

### DIFF
--- a/pkg/connector/api_token.go
+++ b/pkg/connector/api_token.go
@@ -46,11 +46,13 @@ func apiTokenResource(token cloudflare.APIToken) (*v2.Resource, error) {
 		rs.WithSecretType(v2.SecretTrait_CREDENTIAL_TYPE_STATIC_SECRET),
 		rs.WithSecretDetail(apiTokenSecretDetail),
 	}
-	if token.IssuedOn != nil {
-		secretTraitOpts = append(secretTraitOpts, rs.WithSecretCreatedAt(*token.IssuedOn))
-	}
 	if token.ExpiresOn != nil {
 		secretTraitOpts = append(secretTraitOpts, rs.WithSecretExpiresAt(*token.ExpiresOn))
+	}
+
+	resourceOpts := []rs.ResourceOption{}
+	if token.IssuedOn != nil {
+		resourceOpts = append(resourceOpts, rs.WithResourceCreatedAt(*token.IssuedOn))
 	}
 
 	displayName := token.Name
@@ -58,7 +60,7 @@ func apiTokenResource(token cloudflare.APIToken) (*v2.Resource, error) {
 		displayName = token.ID
 	}
 
-	return rs.NewSecretResource(displayName, resourceTypeAPIToken, token.ID, secretTraitOpts)
+	return rs.NewSecretResource(displayName, resourceTypeAPIToken, token.ID, secretTraitOpts, resourceOpts...)
 }
 
 func (o *apiTokenResourceType) List(ctx context.Context, _ *v2.ResourceId, opts rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {

--- a/pkg/connector/api_token_test.go
+++ b/pkg/connector/api_token_test.go
@@ -36,8 +36,10 @@ func TestAPITokenResource(t *testing.T) {
 
 	assert.Equal(t, v2.SecretTrait_CREDENTIAL_TYPE_STATIC_SECRET, secretTrait.GetCredentialType())
 	assert.Equal(t, apiTokenSecretDetail, secretTrait.GetCredentialDetail())
-	assert.Equal(t, issued, secretTrait.GetCreatedAt().AsTime())
 	assert.Equal(t, expires, secretTrait.GetExpiresAt().AsTime())
+
+	// created_at lives on the resource, not the secret trait.
+	assert.Equal(t, issued, resource.GetCreatedAt().AsTime())
 }
 
 func TestAPITokenResourceFallbackDisplayName(t *testing.T) {

--- a/pkg/connector/invitation.go
+++ b/pkg/connector/invitation.go
@@ -18,7 +18,10 @@ import (
 	"golang.org/x/text/language"
 )
 
-const userStatusPending = "pending"
+const (
+	userStatusPending  = "pending"
+	userStatusAccepted = "accepted"
+)
 
 type InvitationResourceType struct {
 	resourceType *v2.ResourceType
@@ -40,15 +43,20 @@ func invitationResource(member cloudflare.AccountMember) (*v2.Resource, error) {
 	}
 
 	userTraits := []rs.UserTraitOption{
-		rs.WithUserProfile(profile),
-		rs.WithDetailedStatus(v2.UserTrait_Status_STATUS_ENABLED, status),
 		rs.WithUserLogin(email),
 		rs.WithEmail(email, true),
 	}
 
 	// member.ID (the membership UUID) is used as the resource ID because member.User.ID
 	// is empty for pending invitations until the user accepts and gets a Cloudflare UUID.
-	resource, err := rs.NewUserResource(email, resourceTypeInvitation, member.ID, userTraits)
+	resource, err := rs.NewUserResource(
+		email,
+		resourceTypeInvitation,
+		member.ID,
+		userTraits,
+		rs.WithResourceProfile(profile),
+		rs.WithResourceStatus(v2.Status_RESOURCE_STATUS_ENABLED, status),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -231,9 +231,10 @@ func (r *roleResourceType) Grant(ctx context.Context, principal *v2.Resource, en
 		return nil, fmt.Errorf("baton-cloudflare: only users can be granted role membership")
 	}
 
-	// The member ID is written to the resource-level profile during sync; fall back to
-	// an API lookup for resources synced before the profile moved off the user trait.
-	memberId, found := rs.GetProfileStringValue(principal.GetProfile(), memberIdProfileKey)
+	// The member ID is written to the resource-level profile during sync; rs.GetProfile
+	// falls back to the deprecated trait profile for resources synced before the move,
+	// and an API lookup covers anything still missing it.
+	memberId, found := rs.GetProfileStringValue(rs.GetProfile(principal), memberIdProfileKey)
 	if !found || memberId == "" {
 		var err error
 		memberId, err = findMemberIDByUserID(ctx, r.client, r.accountId, userId)
@@ -378,9 +379,10 @@ func (r *roleResourceType) Revoke(ctx context.Context, grant *v2.Grant) (annotat
 	userId := principal.Id.Resource
 	roleId := entitlement.Resource.Id.Resource
 
-	// The member ID is written to the resource-level profile during sync; fall back to
-	// an API lookup for resources synced before the profile moved off the user trait.
-	memberId, found := rs.GetProfileStringValue(principal.GetProfile(), memberIdProfileKey)
+	// The member ID is written to the resource-level profile during sync; rs.GetProfile
+	// falls back to the deprecated trait profile for resources synced before the move,
+	// and an API lookup covers anything still missing it.
+	memberId, found := rs.GetProfileStringValue(rs.GetProfile(principal), memberIdProfileKey)
 	if !found || memberId == "" {
 		var err error
 		memberId, err = findMemberIDByUserID(ctx, r.client, r.accountId, userId)

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -51,16 +51,13 @@ func roleResource(role cloudflare.AccountRole, resourceTypeRole *v2.ResourceType
 		"role_name": role.Name,
 	}
 
-	roleTraitOptions := []rs.RoleTraitOption{
-		rs.WithRoleProfile(profile),
-	}
-
 	ret, err := rs.NewRoleResource(
 		role.Name,
 		resourceTypeRole,
 		role.ID,
-		roleTraitOptions,
+		nil,
 		rs.WithParentResourceID(parentResourceID),
+		rs.WithResourceProfile(profile),
 	)
 	if err != nil {
 		return nil, err
@@ -234,13 +231,11 @@ func (r *roleResourceType) Grant(ctx context.Context, principal *v2.Resource, en
 		return nil, fmt.Errorf("baton-cloudflare: only users can be granted role membership")
 	}
 
-	userTrait, err := rs.GetUserTrait(principal)
-	if err != nil {
-		return nil, fmt.Errorf("baton-cloudflare: user trait not found on principal")
-	}
-
-	memberId, found := rs.GetProfileStringValue(userTrait.GetProfile(), memberIdProfileKey)
+	// The member ID is written to the resource-level profile during sync; fall back to
+	// an API lookup for resources synced before the profile moved off the user trait.
+	memberId, found := rs.GetProfileStringValue(principal.GetProfile(), memberIdProfileKey)
 	if !found || memberId == "" {
+		var err error
 		memberId, err = findMemberIDByUserID(ctx, r.client, r.accountId, userId)
 		if err != nil {
 			return nil, err
@@ -383,13 +378,11 @@ func (r *roleResourceType) Revoke(ctx context.Context, grant *v2.Grant) (annotat
 	userId := principal.Id.Resource
 	roleId := entitlement.Resource.Id.Resource
 
-	userTrait, err := rs.GetUserTrait(principal)
-	if err != nil {
-		return nil, fmt.Errorf("baton-cloudflare: user trait not found on principal")
-	}
-
-	memberId, found := rs.GetProfileStringValue(userTrait.GetProfile(), memberIdProfileKey)
+	// The member ID is written to the resource-level profile during sync; fall back to
+	// an API lookup for resources synced before the profile moved off the user trait.
+	memberId, found := rs.GetProfileStringValue(principal.GetProfile(), memberIdProfileKey)
 	if !found || memberId == "" {
+		var err error
 		memberId, err = findMemberIDByUserID(ctx, r.client, r.accountId, userId)
 		if err != nil {
 			return nil, err

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -4,11 +4,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
+
 	"github.com/cloudflare/cloudflare-go"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 const memberIdProfileKey = "member_id"
@@ -27,17 +31,17 @@ func userResource(member cloudflare.AccountMember) (*v2.Resource, error) {
 	user := member.User
 	firstName := user.FirstName
 	lastName := user.LastName
+	status := cases.Title(language.English).String(member.Status)
 	profile := map[string]interface{}{
 		"login":            user.Email,
 		"first_name":       firstName,
 		"last_name":        lastName,
 		"email":            user.Email,
+		"status":           status,
 		memberIdProfileKey: member.ID,
 	}
 
 	userTraits := []rs.UserTraitOption{
-		rs.WithUserProfile(profile),
-		rs.WithStatus(v2.UserTrait_Status_STATUS_UNSPECIFIED),
 		rs.WithUserLogin(user.Email),
 		rs.WithEmail(user.Email, true),
 	}
@@ -47,12 +51,31 @@ func userResource(member cloudflare.AccountMember) (*v2.Resource, error) {
 		displayName = user.Email
 	}
 
-	resource, err := rs.NewUserResource(displayName, resourceTypeUser, user.ID, userTraits)
+	resource, err := rs.NewUserResource(
+		displayName,
+		resourceTypeUser,
+		user.ID,
+		userTraits,
+		rs.WithResourceProfile(profile),
+		rs.WithResourceStatus(memberResourceStatus(member.Status), status),
+	)
 	if err != nil {
 		return nil, err
 	}
 
 	return resource, nil
+}
+
+// memberResourceStatus maps a Cloudflare account member status onto a resource status.
+// The API documents "accepted" and "pending"; List filters pending members out (they
+// sync as invitations), so members reaching here should be accepted. Unrecognized
+// values are reported as disabled rather than silently enabled.
+func memberResourceStatus(memberStatus string) v2.Status_ResourceStatus {
+	if strings.EqualFold(memberStatus, userStatusAccepted) {
+		return v2.Status_RESOURCE_STATUS_ENABLED
+	}
+
+	return v2.Status_RESOURCE_STATUS_DISABLED
 }
 
 func (o *UserResourceType) List(ctx context.Context, _ *v2.ResourceId, opts rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {

--- a/pkg/connector/user_test.go
+++ b/pkg/connector/user_test.go
@@ -1,0 +1,69 @@
+package connector
+
+import (
+	"testing"
+
+	"github.com/cloudflare/cloudflare-go"
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUserResourceStatus(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		memberStatus   string
+		expectedStatus v2.Status_ResourceStatus
+		expectedDetail string
+	}{
+		{"accepted", "accepted", v2.Status_RESOURCE_STATUS_ENABLED, "Accepted"},
+		{"unknown", "rejected", v2.Status_RESOURCE_STATUS_DISABLED, "Rejected"},
+		{"empty", "", v2.Status_RESOURCE_STATUS_DISABLED, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			member := cloudflare.AccountMember{
+				ID:     "member-1",
+				Status: tc.memberStatus,
+				User: cloudflare.AccountMemberUserDetails{
+					ID:        "user-1",
+					Email:     "someone@example.com",
+					FirstName: "Some",
+					LastName:  "One",
+				},
+			}
+
+			resource, err := userResource(member)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expectedStatus, resource.GetStatus().GetStatus())
+			assert.Equal(t, tc.expectedDetail, resource.GetStatus().GetDetails())
+		})
+	}
+}
+
+// The member ID is read back out of the resource-level profile during Grant/Revoke,
+// so it has to survive the move off the user trait.
+func TestUserResourceProfile(t *testing.T) {
+	member := cloudflare.AccountMember{
+		ID:     "member-1",
+		Status: "accepted",
+		User: cloudflare.AccountMemberUserDetails{
+			ID:        "user-1",
+			Email:     "someone@example.com",
+			FirstName: "Some",
+			LastName:  "One",
+		},
+	}
+
+	resource, err := userResource(member)
+	require.NoError(t, err)
+
+	memberID, found := rs.GetProfileStringValue(resource.GetProfile(), memberIdProfileKey)
+	require.True(t, found, "expected %s on the resource profile", memberIdProfileKey)
+	assert.Equal(t, member.ID, memberID)
+
+	email, found := rs.GetProfileStringValue(resource.GetProfile(), "email")
+	require.True(t, found)
+	assert.Equal(t, member.User.Email, email)
+}


### PR DESCRIPTION
Fixes [CXP-854](https://linear.app/ductone/issue/CXP-854/baton-cloudflare-users-synced-with-status-unspecified-causing).

Users were synced with `STATUS_UNSPECIFIED`. Status now comes from the Cloudflare account member record, with the raw value as status details. `accepted` maps to enabled; unrecognized values map to disabled so they don't silently read as enabled (`pending` members are already filtered out and synced as invitations).

Also migrates `profile` / `status` / `created_at` off the deprecated trait options onto the resource. Note the SDK mirrors trait→resource but not the reverse, so the two `member_id` readers in `role.go` had to move to `principal.GetProfile()` — left alone, every Grant/Revoke would have silently degraded into an extra API lookup.

Drops some leftover debug `fmt.Println` calls. No config or permission changes: `Account API Tokens:Read` was already in the annotations and connector.mdx.

## Test plan
- `go build ./...`, `go test ./...`, `golangci-lint run ./pkg/...` all clean
- New `user_test.go` covers the status mapping and asserts `member_id` survives on the resource profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)